### PR TITLE
[BUGFIX] Update resourcePattern

### DIFF
--- a/Classes/ResourceMatcher.php
+++ b/Classes/ResourceMatcher.php
@@ -15,7 +15,7 @@ namespace B13\Http2;
  */
 class ResourceMatcher
 {
-    protected $resourcePattern = '[\'"]?([\w\s\/\-:?.]*)["\']?';
+    protected $resourcePattern = '[\'"]?([\w\s\/\=\-:?.]*)["\']?';
 
     /**
      * @param string $input


### PR DESCRIPTION
The resourcePattern in ResourceMatcher now also matches query strings
that contain `key=val`.

Fixes #1 