### PR TITLE
Prevent pushing not loaded resources

### DIFF
--- a/Classes/ResourceMatcher.php
+++ b/Classes/ResourceMatcher.php
@@ -49,9 +49,9 @@ class ResourceMatcher
      */
     protected function getPattern(): string
     {
-        return '/<script[\/\s\w\-="]* src=' . $this->resourcePattern . '[^>]*>'
+        return '/<script[\/\s\w\-="]*[\s]+src=' . $this->resourcePattern . '[^>]*>'
             . '|' .
-            '<link[\/\s\w\-="]* href=' . $this->resourcePattern . '[^>]*>'
+            '<link[\/\s\w\-="]*[\s]+href=' . $this->resourcePattern . '[^>]*>'
             . '/ui';
     }
 }

--- a/Classes/ResourceMatcher.php
+++ b/Classes/ResourceMatcher.php
@@ -49,9 +49,9 @@ class ResourceMatcher
      */
     protected function getPattern(): string
     {
-        return '/<script[\/\s\w\-="]*src=' . $this->resourcePattern . '[^>]*>'
+        return '/<script[\/\s\w\-="]* src=' . $this->resourcePattern . '[^>]*>'
             . '|' .
-            '<link[\/\s\w\-="]*href=' . $this->resourcePattern . '[^>]*>'
+            '<link[\/\s\w\-="]* href=' . $this->resourcePattern . '[^>]*>'
             . '/ui';
     }
 }


### PR DESCRIPTION
This PR addresses #20 and is basically the same as #22 without the merge conflict and uses the character class `\s` instead of a white space to allow line breaks as well.

If that is for some reason not desired, replacing the added pattern part with `[^data-]` would also solve the issue for most use cases.