### PR TITLE
use 'rel=modulepreload' for .mjs files (EcmaScript modules)

### DIFF
--- a/Classes/Http/ResourcePusher.php
+++ b/Classes/Http/ResourcePusher.php
@@ -49,6 +49,10 @@ class ResourcePusher implements MiddlewareInterface
 
     protected function addPreloadHeaderToResponse(ResponseInterface $response, string $uri, string $type): ResponseInterface
     {
-        return $response->withAddedHeader('Link', '<' . htmlspecialchars(PathUtility::getAbsoluteWebPath($uri)) . '>; rel=preload; as=' . $type);
+        if(str_contains($uri, '.mjs')) {
+            return $response->withAddedHeader('Link', '<' . htmlspecialchars(PathUtility::getAbsoluteWebPath($uri)) . '>; rel=modulepreload; as=' . $type);
+        } else {
+            return $response->withAddedHeader('Link', '<' . htmlspecialchars(PathUtility::getAbsoluteWebPath($uri)) . '>; rel=preload; as=' . $type);
+        }
     }
 }


### PR DESCRIPTION
Fix for #28 