### PR TITLE
[FEATURE] provide an event before data are added to cache

### DIFF
--- a/Classes/Event/BeforeDataAreAddedToCacheEvent.php
+++ b/Classes/Event/BeforeDataAreAddedToCacheEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Http2\Event;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "http2" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use Psr\Http\Message\RequestInterface;
+
+final class BeforeDataAreAddedToCacheEvent
+{
+    public function __construct(
+        public readonly RequestInterface $request,
+        public array $cacheTags,
+    ) {}
+}

--- a/Classes/PageRendererHook.php
+++ b/Classes/PageRendererHook.php
@@ -12,6 +12,8 @@ namespace B13\Http2;
  * of the License, or any later version.
  */
 
+use B13\Http2\Event\BeforeDataAreAddedToCacheEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -34,7 +36,8 @@ class PageRendererHook
     public function __construct(
         #[Autowire(service: 'cache.tx_http2')]
         private readonly FrontendInterface $cache,
-        protected ResourceMatcher $matcher
+        protected ResourceMatcher $matcher,
+        protected EventDispatcherInterface $eventDispatcher
     ) {}
 
     /**
@@ -107,6 +110,9 @@ class PageRendererHook
         $identifier = $cacheDataCollector->getPageCacheIdentifier();
         $cacheTags = array_map(fn(CacheTag $cacheTag) => $cacheTag->name, $cacheDataCollector->getCacheTags());
         $cacheTimeout = $cacheDataCollector->resolveLifetime();
+        $beforeDataAreAddedToCacheEvent = new BeforeDataAreAddedToCacheEvent($request, $cacheTags);
+        $this->eventDispatcher->dispatch($beforeDataAreAddedToCacheEvent);
+        $cacheTags = $beforeDataAreAddedToCacheEvent->cacheTags;
         $this->cache->set($identifier, $data, $cacheTags, $cacheTimeout);
     }
 


### PR DESCRIPTION
this event allows you to modify the cacheTags.
can be usefull if page-cache has a lot of tags (e.g. EXT:menus is installed) and you want to reduce the cacheTags to the page cache tag 'pageId_<id>'